### PR TITLE
Fix: Add odoc in the dependency and rename doc to docs in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt doc clean
+.PHONY: build test fmt docs clean
 
 build:
 	dune build

--- a/lp.opam
+++ b/lp.opam
@@ -18,7 +18,7 @@ depends: [
     "dune" {>= "2.2.0"}
     "menhir" {>= "20180523"}
     "alcotest" {with-test}
-    "odoc" {with-doc}
+    "odoc" {>= "2.4.4" & < "3.0.0" & with-doc}
 ]
 build: [
     [ "dune" "build" "-p" name "-j" jobs ]

--- a/lp.opam
+++ b/lp.opam
@@ -18,6 +18,7 @@ depends: [
     "dune" {>= "2.2.0"}
     "menhir" {>= "20180523"}
     "alcotest" {with-test}
+    "odoc" {with-doc}
 ]
 build: [
     [ "dune" "build" "-p" name "-j" jobs ]


### PR DESCRIPTION
# Fix: Add `odoc` as a dependency and rename `doc` to `docs` in the Makefile

This pull-request adds `odoc` as a dependency for `lp` using `{with-doc}`  
and renames the `.PHONY` target `doc` to `docs` in the `Makefile`.

## Problem 1: Missing `odoc` Dependency

The current `lp.opam` does not specify `odoc` as a dependency,  
so users must install it manually.

I believe this situation can be improved.
Installing `odoc` separately can be a minor inconvenience for users  
who prefer a more streamlined setup.

That said, this issue is not critical,
and the current approach can still be used.

## Problem 2: Incorrect `.PHONY` Target in the Makefile

The current `Makefile` defines `.PHONY: doc` at the beginning,  
but the actual target name appears to be `docs`.

    .PHONY: build test fmt doc clean

    build:
        dune build

    test:
        dune runtest

    fmt:
        dune build @fmt --auto-promote

    docs:
        dune build @doc
        rm -rf docs
        cp -r _build/default/_doc/_html docs
        touch docs/.nojekyll

    clean:
        dune clean

Using this `Makefile`, running `make doc` fails with the following error:

    make: *** No rule to make target 'doc'.  Stop.

Additionally, running `make docs` first checks for the existence of the `docs` directory.  
If the directory already exists, the command does nothing,  
even if the documentation has changed and needs to be regenerated.  
The output is as follows:

    make: 'docs' is up to date.

I believe `doc` is a typo and should be corrected to `docs`.

## Proposed Solution

This pull request makes the following changes.

First, it adds `odoc` as a dependency for `lp` using `{with-doc}`.  
With this change, users can install `odoc` simply by adding  
the `--with-doc` flag to their opam command:

    opam install . --with-test --with-doc

Second, it renames the `.PHONY` target `doc` to `docs` in the `Makefile`.  
With this change, running `make docs` will always regenerate the `docs` directory,  
which I believe is the expected behavior.

Additionally, running `make docs` in the current version  
[ad3d5fe105899cb684452e27638bd1a76d9f3138](https://github.com/ktahar/ocaml-lp/commit/ad3d5fe105899cb684452e27638bd1a76d9f3138)  
produces a different set of HTML files when using `odoc` version `2.4.4` in my environment.

## Discussion

It may be beneficial to specify a particular version of `odoc`,  
as different versions might generate slightly different HTML files.

However, many other OCaml projects, including `omd`,  
do not enforce a specific `odoc` version.  
For reference, here is the `opam` file for the `omd` tool:  
[omd.opam](https://github.com/ocaml-community/omd/blob/master/omd.opam).

Again, I fully respect your decision and
I am happy to adjust or abandon this patch based on your preference.

I would appreciate your review of this patch. Thank you!
